### PR TITLE
pdaf: Changes for compiling eCLM-PDAF 

### DIFF
--- a/src/eclm/CMakeLists.txt
+++ b/src/eclm/CMakeLists.txt
@@ -1,7 +1,7 @@
 project (eclm LANGUAGES Fortran)
 
-add_executable(${PROJECT_NAME})
-set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".exe")
+add_library(${PROJECT_NAME} STATIC)
+# set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".exe")
 
 target_sources(${PROJECT_NAME} 
   PRIVATE

--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -179,7 +179,7 @@ module cime_comp_mod
 
   implicit none
 
-  private
+  ! private
 
   public cime_pre_init1, cime_pre_init2, cime_init, cime_run, cime_final
   public timing_dir, mpicom_GLOID


### PR DESCRIPTION
### comment out `private` statement in `cime_comp_mod.F90`
In TSMP-PDAF interface routine `enkf_clm_5.F90` private variables of `cime_comp_mod.F90` are used.

Resolves: https://github.com/HPSCTerrSys/eTSMP/issues/10


### Library target for `src/eclm` instead of executable

For TSMP-PDAF, we need eCLM to be compiled as a library.