### PR TITLE
USE_PDAF: `mpi_init` call in `cime_comp_mod` switched off for PDAF

### DIFF
--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -610,8 +610,10 @@ contains
     integer :: driver_id, oas_comp_id
     integer :: driver_comm
 
+#ifndef USE_PDAF
     call mpi_init(ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_init')
+#endif
 
 #if defined(USE_OASIS)
     call oasis_init_comp  (oas_comp_id, 'eCLM', ierr)


### PR DESCRIPTION
Otherwise, an error for duplicate calling of `mpi_init` is thrown, since PDAF calls `mpi_init` in its main routine `pdaf_terrsysmp.F90`.