### PR TITLE
Remove datm_comp_run() when coupled to ICON

### DIFF
--- a/src/datm/atm_comp_mct.F90
+++ b/src/datm/atm_comp_mct.F90
@@ -244,6 +244,7 @@ CONTAINS
          orb_lambm0=orbLambm0, &
          orb_obliqr=orbObliqr)
 
+#ifndef COUP_OAS_ICON
     call datm_comp_run( &
          EClock = EClock, &
          x2a = x2a, &
@@ -263,6 +264,7 @@ CONTAINS
          orbObliqr = orbObliqr, &
          nextsw_cday = nextsw_cday, &
          case_name = case_name)
+#endif
 
     call seq_infodata_PutData(infodata, nextsw_cday=nextsw_cday )
 


### PR DESCRIPTION
This excludes only the `datm_comp_run()` call when running ICON.

Improvements could include:
- Get higher in calling tree, e.g. block out code from [`cime_run()`](src/datm/datm_comp_mod.F90)
- Block out all datm code
- Use runtime flags instead