### PR TITLE
Introduce `cime_run(ntsteps)`, callable for TSMP-PDAF

### DIFF
--- a/src/csm_share/mct/seq_comm_mct.F90
+++ b/src/csm_share/mct/seq_comm_mct.F90
@@ -611,15 +611,11 @@ contains
           pelist(2,1) = cmax(n)
           pelist(3,1) = cstr(n)
        endif
-#ifdef USE_PDAF
-       !write(*,*) "before seq_comm_set_comm bcast", pelist, DRIVER_COMM
-#endif
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, DRIVER_COMM, ierr)
+
 #ifdef USE_PDAF
        if (present(pdaf_id) .and. present(pdaf_max)) then
-         !write(*,*) "before seq_comm_setcomm", pdaf_id, pdaf_max, mype, n, &
-         !           COMPID(n), pelist, comp_nthreads, name
-         call seq_comm_setcomm(COMPID(n),pelist,nthreads=comp_nthreads,iname=name,inst=pdaf_id,tinst=pdaf_max)
+          call seq_comm_setcomm(COMPID(n),pelist,nthreads=comp_nthreads,iname=name,inst=pdaf_id,tinst=pdaf_max)
        else if (present(drv_comm_id)) then
 #else
        if (present(drv_comm_id)) then

--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -2252,6 +2252,16 @@ contains
     call t_stopf ('CPL:RUN_LOOP_BSTART')
     Time_begin = mpi_wtime()
     Time_bstep = mpi_wtime()
+
+#ifdef USE_PDAF
+    ! Check for optional input `ntsteps`
+    if(.not. present(ntsteps)) then
+      write(logunit,*) 'ERROR: ntsteps input not present, but needed for TSMP-PDAF ;'
+      call shr_sys_abort(subname// &
+        ' missing ntsteps input that is needed for TSMP-PDAF')
+    end if
+#endif
+
     do while ( .not. stop_alarm)
 
        call t_startf('CPL:RUN_LOOP', hashint(1))

--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -4109,6 +4109,11 @@ contains
       ! TSMP specific stop condition:
       counter = counter + 1
       if (present(ntsteps) .and. counter == ntsteps) then
+        if (iamroot_CPLID) then
+          write(logunit,*) ' '
+          write(logunit,103) subname,' NOTE: Stopping from TSMP-PDAF alarm ntsteps'
+          write(logunit,*) ' '
+        endif
         stop_alarm = .true.
       end if
 #endif

--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -2260,6 +2260,9 @@ contains
       call shr_sys_abort(subname// &
         ' missing ntsteps input that is needed for TSMP-PDAF')
     end if
+
+    ! Explicitly set `counter` to zero before loop
+    counter = 0
 #endif
 
     do while ( .not. stop_alarm)


### PR DESCRIPTION
1. Re-introduce `private` statement, this was removed because variables from `cime_comp_mod` had to be used by TSMP-PDAF

2. Add `cime_run` with number of time steps `ntsteps` as input. `ntsteps` is supplied by the TSMP-PDAF interface.

3. Add `stop_alarm` for `cime_run` dependent on `ntsteps`.