### PR TITLE
Refactor to modify x2l instead of atm2lnd

### DIFF
--- a/src/clm5/cpl/lnd_comp_mct.F90
+++ b/src/clm5/cpl/lnd_comp_mct.F90
@@ -405,6 +405,7 @@ contains
          rof_prognostic=rof_prognostic, &
          glc_present=glc_present)
 
+#ifndef COUP_OAS_ICON
     ! Map MCT to land data type
     ! Perform downscaling if appropriate
 
@@ -418,6 +419,7 @@ contains
          atm2lnd_inst = atm2lnd_inst, &
          glc2lnd_inst = glc2lnd_inst)
     call t_stopf ('lc_lnd_import')
+#endif
     ! Use infodata to set orbital values if updated mid-run
 
 
@@ -460,7 +462,15 @@ contains
        if (nlend_sync .and. dosend) nlend = .true.
 
 #ifdef COUP_OAS_ICON
-       call oas_receive_icon(bounds, time_elapsed, atm2lnd_inst)
+       call oas_receive_icon(bounds, time_elapsed, x2l = x2l_l%rattr)
+
+       call t_startf ('lc_lnd_import')
+       call lnd_import( bounds, &
+          x2l = x2l_l%rattr, &
+          glc_present = glc_present, &
+          atm2lnd_inst = atm2lnd_inst, &
+          glc2lnd_inst = glc2lnd_inst)
+       call t_stopf ('lc_lnd_import')
 #endif
 
 #ifdef COUP_OAS_PFL

--- a/src/clm5/cpl/lnd_import_export.F90
+++ b/src/clm5/cpl/lnd_import_export.F90
@@ -204,6 +204,7 @@ contains
 
        atm2lnd_inst%forc_rh_grc(g) = 100.0_r8*(forc_q / qsat)
 
+#ifndef COUP_OAS_ICON
        ! Check that solar, specific-humidity and LW downward aren't negative
        if ( atm2lnd_inst%forc_lwrad_not_downscaled_grc(g) <= 0.0_r8 )then
           call endrun( sub//' ERROR: Longwave down sent from the atmosphere model is negative or zero' )
@@ -216,6 +217,7 @@ contains
        if ( atm2lnd_inst%forc_q_not_downscaled_grc(g) < 0.0_r8 )then
           call endrun( sub//' ERROR: Bottom layer specific humidty sent from the atmosphere model is less than zero' )
        end if
+#endif
 
        ! Check if any input from the coupler is NaN
        if ( any(isnan(x2l(:,i))) )then

--- a/src/clm5/oasis3/oas_sendReceiveMod.F90
+++ b/src/clm5/oasis3/oas_sendReceiveMod.F90
@@ -6,7 +6,6 @@ module oas_sendReceiveMod
   use clm_varctl       , only: iulog
   use oas_vardefMod
   use mod_oasis
-  use clm_cpl_indices
   implicit none
   save
   private
@@ -56,6 +55,7 @@ contains
 #ifdef COUP_OAS_ICON
   subroutine oas_receive_icon(bounds, seconds_elapsed, x2l)
     use atm2lndType, only: atm2lnd_type
+    use clm_cpl_indices
 
     type(bounds_type),  intent(in)    :: bounds
     integer          ,  intent(in)    :: seconds_elapsed

--- a/src/clm5/oasis3/oas_sendReceiveMod.F90
+++ b/src/clm5/oasis3/oas_sendReceiveMod.F90
@@ -6,6 +6,7 @@ module oas_sendReceiveMod
   use clm_varctl       , only: iulog
   use oas_vardefMod
   use mod_oasis
+  use clm_cpl_indices
   implicit none
   save
   private
@@ -53,43 +54,42 @@ contains
 #endif
 
 #ifdef COUP_OAS_ICON
-  subroutine oas_receive_icon(bounds, seconds_elapsed, atm2lnd_inst)
+  subroutine oas_receive_icon(bounds, seconds_elapsed, x2l)
     use atm2lndType, only: atm2lnd_type
 
     type(bounds_type),  intent(in)    :: bounds
     integer          ,  intent(in)    :: seconds_elapsed
-    type(atm2lnd_type), intent(inout) :: atm2lnd_inst
+    real(r8)         ,  intent(inout) :: x2l(:,:) ! driver import state to land model
     real(kind=r8),      allocatable   :: buffer(:,:)
     integer                           :: num_grid_points
     integer                           :: info
-    integer                           :: g
+    integer                           :: g, i
 
 
     num_grid_points = (bounds%endg - bounds%begg) + 1
     allocate(buffer(num_grid_points, 1))
 
     !    call oasis_get(oas_id_t, seconds_elapsed, oas_rcv_meta(:,:,oas_id_t), info)
-    call oasis_get(oas_id_t,  seconds_elapsed, atm2lnd_inst%forc_t_not_downscaled_grc, info)
-    call oasis_get(oas_id_u,  seconds_elapsed, atm2lnd_inst%forc_u_grc, info)
-    call oasis_get(oas_id_v,  seconds_elapsed, atm2lnd_inst%forc_v_grc, info)
-    call oasis_get(oas_id_qv, seconds_elapsed, atm2lnd_inst%forc_q_not_downscaled_grc, info)
-    call oasis_get(oas_id_ht, seconds_elapsed, atm2lnd_inst%forc_hgt_grc, info)
-    call oasis_get(oas_id_pr, seconds_elapsed, atm2lnd_inst%forc_pbot_not_downscaled_grc, info)
-    call oasis_get(oas_id_rs, seconds_elapsed, atm2lnd_inst%forc_solad_grc(:,1), info)
-    call oasis_get(oas_id_fs, seconds_elapsed, atm2lnd_inst%forc_solai_grc(:,1), info)
-    call oasis_get(oas_id_lw, seconds_elapsed, atm2lnd_inst%forc_lwrad_not_downscaled_grc, info)
-    call oasis_get(oas_id_cr, seconds_elapsed, atm2lnd_inst%forc_rain_not_downscaled_grc, info)
-    call oasis_get(oas_id_gr, seconds_elapsed, atm2lnd_inst%forc_snow_not_downscaled_grc, info)
-
-    !SPo: some postprocessing of atm2lnd is missing; may better use x2l 
+    call oasis_get(oas_id_t,  seconds_elapsed, x2l(index_x2l_Sa_tbot,:), info)
+    call oasis_get(oas_id_u,  seconds_elapsed, x2l(index_x2l_Sa_u,:), info)
+    call oasis_get(oas_id_v,  seconds_elapsed, x2l(index_x2l_Sa_v,:), info)
+    call oasis_get(oas_id_qv, seconds_elapsed, x2l(index_x2l_Sa_shum,:), info)
+    call oasis_get(oas_id_ht, seconds_elapsed, x2l(index_x2l_Sa_z,:), info)
+    call oasis_get(oas_id_pr, seconds_elapsed, x2l(index_x2l_Sa_pbot,:), info)
+    call oasis_get(oas_id_rs, seconds_elapsed, x2l(index_x2l_Faxa_swvdr,:), info)
+    call oasis_get(oas_id_fs, seconds_elapsed, x2l(index_x2l_Faxa_swvdf,:), info)
+    call oasis_get(oas_id_lw, seconds_elapsed, x2l(index_x2l_Faxa_lwdn,:), info)
+    call oasis_get(oas_id_cr, seconds_elapsed, x2l(index_x2l_Faxa_rainl,:), info)
+    call oasis_get(oas_id_gr, seconds_elapsed, x2l(index_x2l_Faxa_snowl,:), info)
+    x2l(index_x2l_Faxa_rainc,:) = 0.
+    x2l(index_x2l_Faxa_snowc,:) = 0.
 
     do g=bounds%begg,bounds%endg
-       atm2lnd_inst%forc_solad_grc(g,1) = 0.5_r8 * atm2lnd_inst%forc_solad_grc(g,1)
-       atm2lnd_inst%forc_solad_grc(g,2) = atm2lnd_inst%forc_solad_grc(g,1)
-       atm2lnd_inst%forc_solai_grc(g,1) = 0.5_r8 * atm2lnd_inst%forc_solai_grc(g,1)
-       atm2lnd_inst%forc_solai_grc(g,2) = atm2lnd_inst%forc_solai_grc(g,1)
-       atm2lnd_inst%forc_solar_grc(g)   =  atm2lnd_inst%forc_solad_grc(g,2) + atm2lnd_inst%forc_solad_grc(g,1) &
-                                        +  atm2lnd_inst%forc_solai_grc(g,2) + atm2lnd_inst%forc_solai_grc(g,1)
+       i = 1 + (g - bounds%begg)
+       x2l(index_x2l_Faxa_swvdr,i) = 0.5_r8 * x2l(index_x2l_Faxa_swvdr,i)
+       x2l(index_x2l_Faxa_swndr,i) = x2l(index_x2l_Faxa_swvdr,i)
+       x2l(index_x2l_Faxa_swvdf,i) = 0.5_r8 * x2l(index_x2l_Faxa_swvdf,i)
+       x2l(index_x2l_Faxa_swndf,i) = x2l(index_x2l_Faxa_swvdf,i)
     enddo
 
   end subroutine oas_receive_icon


### PR DESCRIPTION
Here `x2l` is updated by ICON variables instead of `atm2lnd`.

It is strictly not a pure refactoring of the `master` code, because the output is *different*.  However, the output from `refac-x2l-incr` is *identical* (in any output variables for any timestep) to that in [`master+vars+patch`](https://github.com/HPSCTerrSys/eCLM/compare/master...mvhulten:eCLM:master+vars+patch).  The branch `master+vars+patch` is a (somewhat messy) bug fix to `master` without any refactoring.  It is only meant as a proof of concept to show that **`refac-x2l-incr`** is good to merge.