### PR TITLE
Winter wheat changes by Theresa Boas

### DIFF
--- a/src/clm5/biogeochem/CNNDynamicsMod.F90
+++ b/src/clm5/biogeochem/CNNDynamicsMod.F90
@@ -304,7 +304,7 @@ contains
     !
     ! !USES:
     use pftconMod, only : ntmp_soybean, nirrig_tmp_soybean
-    use pftconMod, only : ntrp_soybean, nirrig_trp_soybean
+    !use pftconMod, only : ntrp_soybean, nirrig_trp_soybean
     !
     ! !ARGUMENTS:
     type(bounds_type)                       , intent(in)    :: bounds  
@@ -362,9 +362,9 @@ contains
 
          if (croplive(p) .and. &
               (patch%itype(p) == ntmp_soybean .or. &
-               patch%itype(p) == nirrig_tmp_soybean .or. &
-               patch%itype(p) == ntrp_soybean .or. &
-               patch%itype(p) == nirrig_trp_soybean) ) then
+               patch%itype(p) == nirrig_tmp_soybean)) then !.or. &
+               !patch%itype(p) == ntrp_soybean .or. &
+               !patch%itype(p) == nirrig_trp_soybean) ) then
 
             ! difference between supply and demand
 

--- a/src/clm5/biogeochem/NutrientCompetitionCLM45defaultMod.F90
+++ b/src/clm5/biogeochem/NutrientCompetitionCLM45defaultMod.F90
@@ -498,7 +498,7 @@ contains
     ! !USES:
     use pftconMod              , only : npcropmin, pftcon
     use pftconMod              , only : ntmp_soybean, nirrig_tmp_soybean
-    use pftconMod              , only : ntrp_soybean, nirrig_trp_soybean
+    !use pftconMod              , only : ntrp_soybean, nirrig_trp_soybean
     use clm_varcon             , only : secspday
     use clm_varctl             , only : use_c13, use_c14
     use clm_time_manager       , only : get_step_size
@@ -855,8 +855,8 @@ contains
                   !they all seemed to be going through the retranslocation loop for soybean - good news.
 
                    if (astem(p) == astemf(ivt(p)) .or. &
-                       (ivt(p) /= ntmp_soybean .and. ivt(p) /= nirrig_tmp_soybean .and.&
-                        ivt(p) /= ntrp_soybean .and. ivt(p) /= nirrig_trp_soybean)) then
+                       (ivt(p) /= ntmp_soybean .and. ivt(p) /= nirrig_tmp_soybean)) then ! .and.&
+                        !ivt(p) /= ntrp_soybean .and. ivt(p) /= nirrig_trp_soybean)) then
                      if (grain_flag(p) == 0._r8)then
                      if(.not.use_fun) then
                         t1 = 1 / dt

--- a/src/clm5/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/clm5/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -1188,7 +1188,7 @@ contains
     ! !USES:
     use pftconMod              , only : npcropmin, pftcon
     use pftconMod              , only : ntmp_soybean, nirrig_tmp_soybean
-    use pftconMod              , only : ntrp_soybean, nirrig_trp_soybean
+    !use pftconMod              , only : ntrp_soybean, nirrig_trp_soybean
     use clm_varcon             , only : secspday, dzsoi_decomp
     use clm_varctl             , only : use_c13, use_c14
     use clm_varctl             , only : nscalar_opt, plant_ndemand_opt, substrate_term_opt, temp_scalar_opt
@@ -1574,8 +1574,8 @@ contains
                   !they all seemed to be going through the retranslocation loop for soybean - good news.
 
                   if (astem(p) == astemf(ivt(p)) .or. &
-                       (ivt(p) /= ntmp_soybean .and. ivt(p) /= nirrig_tmp_soybean .and.&
-                        ivt(p) /= ntrp_soybean .and. ivt(p) /= nirrig_trp_soybean)) then
+                       (ivt(p) /= ntmp_soybean .and. ivt(p) /= nirrig_tmp_soybean) ) then !.and.&
+                        !ivt(p) /= ntrp_soybean .and. ivt(p) /= nirrig_trp_soybean)) then
                      if (grain_flag(p) == 0._r8) then
                         t1 = 1 / dt
                         leafn_to_retransn(p) = t1 * max(leafn(p)- (leafc(p) / fleafcn(ivt(p))),0._r8)

--- a/src/clm5/main/clm_varpar.F90
+++ b/src/clm5/main/clm_varpar.F90
@@ -44,7 +44,7 @@ module clm_varpar
   integer, parameter :: ndst        =   4     ! number of dust size classes (BGC only)
   integer, parameter :: dst_src_nbr =   3     ! number of size distns in src soil (BGC only)
   integer, parameter :: sz_nbr      = 200     ! number of sub-grid bins in large bin of dust size distribution (BGC only)
-  integer, parameter :: mxpft       =  78     ! maximum number of PFT's for any mode;
+  integer, parameter :: mxpft       =  78    ! maximum number of PFT's for any mode;
   ! FIX(RF,032414) might we set some of these automatically from reading pft-physiology?
   integer, parameter :: numveg      =  16     ! number of veg types (without specific crop)
   integer, parameter :: nlayer      =   3     ! number of VIC soil layer --Added by AWang
@@ -52,7 +52,7 @@ module clm_varpar
   integer, parameter :: nvariants   =   2     ! number of variants of PFT constants
 
   integer :: numpft      = mxpft   ! actual # of pfts (without bare)
-  integer :: numcft      =  64     ! actual # of crops (includes unused CFTs that are merged into other CFTs)
+  integer :: numcft      =  64    ! actual # of crops (includes unused CFTs that are merged into other CFTs)
   integer :: maxpatch_urb= 5       ! max number of urban patches (columns) in urban landunit
 
   integer :: maxpatch_pft        ! max number of plant functional types in naturally vegetated landunit (namelist setting)


### PR DESCRIPTION
Equivalent to [winter wheat CLM5 patches](https://github.com/tboas/CTSM/commit/0b38504117e9d4b7e94586bdd26c631cc855266e) by @tboas. Modifications include:


1. Addition of several CFTs to source code files for active simulation (as opposed to being merged into other CFTs)
2. Addition of winter wheat subroutines after Lu et al. (2017): https://doi.org/10.5194/gmd-10-1873-2017
3. Addition of cover cropping subroutine that allows multiple crop types on the same column within one year 

For additional information and results please see:

> Boas, T., Bogena, H., Grünwald, T., Heinesch, B., Ryu, D., Schmidt, M., Vereecken, H., Western, A., and Hendricks Franssen, H.-J.: **Improving the representation of cropland sites in the Community Land Model (CLM) version 5.0**, Geosci. Model Dev., 14, 573–601, https://doi.org/10.5194/gmd-14-573-2021, 2021.

