### PR TITLE
eCLM-PDAF related changes concerning `cpl_inst_tag`

### DIFF
--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -658,6 +658,10 @@ contains
     !   if (Global_comm /= MPI_COMM_NULL) then
 
     if (num_inst_driver > 1) then
+#ifdef USE_PDAF
+      call shr_sys_abort( subname//':: num_inst_driver > 1'// &
+        ' not supported for PDAF' )
+#endif
        call seq_comm_init(global_comm, driver_comm, NLFileName, drv_comm_ID=driver_id)
        write(cpl_inst_tag,'("_",i4.4)') driver_id
 #ifdef USE_PDAF

--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -661,18 +661,23 @@ contains
 #ifdef USE_PDAF
       call shr_sys_abort( subname//':: num_inst_driver > 1'// &
         ' not supported for PDAF' )
-#endif
+#else
        call seq_comm_init(global_comm, driver_comm, NLFileName, drv_comm_ID=driver_id)
        write(cpl_inst_tag,'("_",i4.4)') driver_id
-#ifdef USE_PDAF
-    else if (present(pdaf_id) .and. present(pdaf_max)) then
-       call seq_comm_init(global_comm, driver_comm, NLFileName, &
-                          pdaf_id=pdaf_id, pdaf_max=pdaf_max)
-       cpl_inst_tag = ''
 #endif
     else
+#ifdef USE_PDAF
+      if (present(pdaf_id) .and. present(pdaf_max)) then
+        call seq_comm_init(global_comm, driver_comm, NLFileName, pdaf_id=pdaf_id, pdaf_max=pdaf_max)
+        cpl_inst_tag = ''
+      else
+        call shr_sys_abort( subname//':: pdaf_id and pdaf_max'// &
+          ' have to be present for PDAF' )
+      end if
+#else
        call seq_comm_init(global_comm, driver_comm, NLFileName)
        cpl_inst_tag = ''
+#endif
     end if
 
     !--- set task based threading counts ---

--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -664,6 +664,7 @@ contains
     else if (present(pdaf_id) .and. present(pdaf_max)) then
        call seq_comm_init(global_comm, driver_comm, NLFileName, &
                           pdaf_id=pdaf_id, pdaf_max=pdaf_max)
+       cpl_inst_tag = ''
 #endif
     else
        call seq_comm_init(global_comm, driver_comm, NLFileName)


### PR DESCRIPTION
PDAF: Adding to set `cpl_inst_tag = ""` when `USE_PDAF` is true in this code:

https://github.com/HPSCTerrSys/eCLM/blob/4582f148490edf621cbc1a6f11692017bc344469/src/eclm/cime_comp_mod.F90#L660-L671


### Error in restart file

Currently there is an error when attempting to write restart files (see usage of `cpl_inst_tag`:

https://github.com/HPSCTerrSys/eCLM/blob/4582f148490edf621cbc1a6f11692017bc344469/src/eclm/cime_comp_mod.F90#L3739-L3758

In particluar a dummy string is used for `cpl_inst_tag`. Here are a few lines from the `cpl.log` output file:

```
Write restart file at   20290101       0
(seq_rest_write)  write rpointer file rpointer.drv^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@
 (seq_io_wopen)  create file clmoas.cpl^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@.r.2029-01-01-00000.nc
```

### cpl_modelio.nml issue

Additionally, `cpl_modelio.nml` seems to not be read currently:

https://github.com/HPSCTerrSys/eCLM/blob/4582f148490edf621cbc1a6f11692017bc344469/src/eclm/cime_comp_mod.F90#L817-L829