### PR TITLE
Fix eclm-parflow qparflow

### DIFF
--- a/src/clm5/biogeophys/SoilHydrologyMod.F90
+++ b/src/clm5/biogeophys/SoilHydrologyMod.F90
@@ -2389,16 +2389,16 @@ contains
                   ! qflx_rootsoi_col(c,j) = rootr_col(c,j)*qflx_tran_veg_col(c)
                   ! Convert eCLM fluxes (mm/s) to ParFlow fluxes (1/hr):
                   !    1/hr         =             [mm/s]                  *   [s/hr]   *  [m/mm]  *   [1/m]
-                  qflx_parflow(c,j) = (qflx_infl(c) - qflx_rootsoi(c,j))  * sec_per_hr * m_per_mm * (1/dz(c,j))
+                  qflx_parflow(c,j) = (qflx_infl(c) - qflx_rootsoi(c,j))  * sec_per_hr * m_per_mm * (1._r8/dz(c,j))
                else 
-                  qflx_parflow(c,j) = -qflx_rootsoi(c,j) * sec_per_hr * m_per_mm * (1/dz(c,j))
+                  qflx_parflow(c,j) = -qflx_rootsoi(c,j) * sec_per_hr * m_per_mm * (1._r8/dz(c,j))
                end if
             end do
          end do
 
          do fc = 1, num_hydrologyc
             c = filter_hydrologyc(fc)
-            qflx_drain(c)         = -sum(qflx_parflow(c,:) / sec_per_hr / m_per_mm / (1/dz(c,j)) ) !0._r8
+            qflx_drain(c)         = -sum(qflx_parflow(c,:) * (1._r8/sec_per_hr) * (1._r8/m_per_mm) * dz(c,j) ) ! mm/s
             qflx_drain_perched(c) = 0._r8  
             qflx_rsub_sat(c)      = 0._r8
             qflx_qrgwl(c)         = qflx_snwcp_liq(c)   ! Set imbalance for snow capping

--- a/src/clm5/biogeophys/WaterfluxType.F90
+++ b/src/clm5/biogeophys/WaterfluxType.F90
@@ -73,7 +73,7 @@ module WaterfluxType
      real(r8), pointer :: qflx_adv_col             (:,:) ! col advective flux across different soil layer interfaces [mm H2O/s] [+ downward]
      real(r8), pointer :: qflx_rootsoi_col         (:,:) ! col root and soil water exchange [mm H2O/s] [+ into root]
 #ifdef COUP_OAS_PFL
-     real(r8), pointer :: qflx_parflow_col         (:,:) ! col source/sink flux per soil layer sent to ParFlow [mm H2O/s] [- out from root]
+     real(r8), pointer :: qflx_parflow_col         (:,:) ! col source/sink flux per soil layer sent to ParFlow [1/hr] [- out from root]
 #endif
      real(r8), pointer :: qflx_infl_col            (:)   ! col infiltration (mm H2O /s)
      real(r8), pointer :: qflx_surf_col            (:)   ! col surface runoff (mm H2O /s)

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -162,8 +162,6 @@ contains
     real(r8), parameter :: amC   = 12.0_r8                      ! Atomic mass number for Carbon
     real(r8), parameter :: amO   = 16.0_r8                      ! Atomic mass number for Oxygen
     real(r8), parameter :: amCO2 = amC + 2.0_r8*amO             ! Atomic mass number for CO2
-!    real(r8), parameter :: m_per_mm = 1.e-3_r8                  ! 0.001 meters per mm
-!    real(r8), parameter :: sec_per_hr = 3600                    ! 3600 s in 1 hour
     ! The following converts g of C to kg of CO2
     real(r8), parameter :: convertgC2kgCO2 = 1.0e-3_r8 * (amCO2/amC)
     !------------------------------------------------------------------------

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -162,8 +162,8 @@ contains
     real(r8), parameter :: amC   = 12.0_r8                      ! Atomic mass number for Carbon
     real(r8), parameter :: amO   = 16.0_r8                      ! Atomic mass number for Oxygen
     real(r8), parameter :: amCO2 = amC + 2.0_r8*amO             ! Atomic mass number for CO2
-    real(r8), parameter :: m_per_mm = 1.e-3_r8                  ! 0.001 meters per mm
-    real(r8), parameter :: sec_per_hr = 3600                    ! 3600 s in 1 hour
+!    real(r8), parameter :: m_per_mm = 1.e-3_r8                  ! 0.001 meters per mm
+!    real(r8), parameter :: sec_per_hr = 3600                    ! 3600 s in 1 hour
     ! The following converts g of C to kg of CO2
     real(r8), parameter :: convertgC2kgCO2 = 1.0e-3_r8 * (amCO2/amC)
     !------------------------------------------------------------------------
@@ -433,18 +433,18 @@ contains
          lnd2atm_inst%qflx_parflow_grc   (bounds%begg:bounds%endg, :), &
          c2l_scale_type= 'unity',  l2g_scale_type='unity' )
 
-    do c = bounds%begc, bounds%endc
-     if (col%hydrologically_active(c)) then
-       if (col%itype(c) == istsoil .or. col%itype(c) == istcrop) then
-         g = col%gridcell(c)
-         do j = 1, nlevsoi
-          ! Convert eCLM fluxes (mm/s) to ParFlow fluxes (1/hr): 
-          !             1/hr                 =             [mm/s]                 *   [s/hr]   *  [m/mm]  *     [1/m] 
-          lnd2atm_inst%qflx_parflow_grc(g,j) = lnd2atm_inst%qflx_parflow_grc(g,j) * sec_per_hr * m_per_mm * (1/col%dz(c,j))
-         enddo
-       end if
-     end if
-    end do
+!    do c = bounds%begc, bounds%endc
+!     if (col%hydrologically_active(c)) then
+!       if (col%itype(c) == istsoil .or. col%itype(c) == istcrop) then
+!         g = col%gridcell(c)
+!         do j = 1, nlevsoi
+!          ! Convert eCLM fluxes (mm/s) to ParFlow fluxes (1/hr): 
+!          !             1/hr                 =             [mm/s]                 *   [s/hr]   *  [m/mm]  *     [1/m] 
+!          lnd2atm_inst%qflx_parflow_grc(g,j) = lnd2atm_inst%qflx_parflow_grc(g,j) * sec_per_hr * m_per_mm * (1/col%dz(c,j))
+!         enddo
+!       end if
+!     end if
+!    end do
 #endif
 
   end subroutine lnd2atm

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -433,18 +433,15 @@ contains
          lnd2atm_inst%qflx_parflow_grc   (bounds%begg:bounds%endg, :), &
          c2l_scale_type= 'unity',  l2g_scale_type='unity' )
 
-!    do c = bounds%begc, bounds%endc
-!     if (col%hydrologically_active(c)) then
-!       if (col%itype(c) == istsoil .or. col%itype(c) == istcrop) then
-!         g = col%gridcell(c)
-!         do j = 1, nlevsoi
-!          ! Convert eCLM fluxes (mm/s) to ParFlow fluxes (1/hr): 
-!          !             1/hr                 =             [mm/s]                 *   [s/hr]   *  [m/mm]  *     [1/m] 
-!          lnd2atm_inst%qflx_parflow_grc(g,j) = lnd2atm_inst%qflx_parflow_grc(g,j) * sec_per_hr * m_per_mm * (1/col%dz(c,j))
-!         enddo
-!       end if
-!     end if
-!    end do
+    ! adjust nan values after c2g, need to be rechecked
+    do g = bounds%begg, bounds%endg
+     do j = 1, nlevsoi
+      if (lnd2atm_inst%qflx_parflow_grc(g,j) == spval) then
+       lnd2atm_inst%qflx_parflow_grc(g,j) = 0._r8
+       write(iulog,*)'WARNING: qflx_parflow_grc is nan at grid point ',g,' level',j,' replaced with 0.'
+      end if
+     end do
+    enddo
 #endif
 
   end subroutine lnd2atm


### PR DESCRIPTION
Previously the unit transformation of `qflx_parflow` was done on the grid specific variable, while looping over column level and using column specific values (dz). The unit transformation is moved from `qflx_parflow_grc` to `qflx_parflow_col` to directly apply the unit transformation at column level. 

In addition `qflx_parflow_grc` is checked for nan values and set to zero (might be adjusted when reason for the behavior  is clarified).