### PR TITLE
Add simulation time information for TSMP-PDAF related stop-alarm

### DIFF
--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -4124,8 +4124,7 @@ contains
       if (present(ntsteps) .and. counter == ntsteps) then
         if (iamroot_CPLID) then
           write(logunit,*) ' '
-          write(logunit,103) subname,' NOTE: Stopping from TSMP-PDAF alarm ntsteps'
-          write(logunit,104) '       TSMP-PDAF alarm at ',ymd,tod
+          write(logunit,'(A, A, i10.8, i8)') subname,' NOTE: Stopping from TSMP-PDAF alarm ntsteps at model date = ',ymd,tod
           write(logunit,*) ' '
         endif
         stop_alarm = .true.


### PR DESCRIPTION
Small addition to TSMP-PDAF related stop-alarm: Printing the simulation time.

This provides the information, when CLM is stopped for DA-steps.

This becomes particularly helpful when flexible data assimilation intervals are used (HPSCTerrSys/TSMP#269)