### PR TITLE
eCLM-PDAF: Set process-specific tag in coupler restart file name

### DIFF
--- a/src/eclm/cime_comp_mod.F90
+++ b/src/eclm/cime_comp_mod.F90
@@ -669,7 +669,7 @@ contains
 #ifdef USE_PDAF
       if (present(pdaf_id) .and. present(pdaf_max)) then
         call seq_comm_init(global_comm, driver_comm, NLFileName, pdaf_id=pdaf_id, pdaf_max=pdaf_max)
-        cpl_inst_tag = ''
+        write(cpl_inst_tag,'("_",i4.4)') pdaf_id
       else
         call shr_sys_abort( subname//':: pdaf_id and pdaf_max'// &
           ' have to be present for PDAF' )


### PR DESCRIPTION
eCLM-PDAF simulations experience errors, when multiple processes try to write the same couple restart file (#88).

An exclusive `cpl_inst_tag` for each process (set to `pdaf_id`) should resolve this, as `cpl_inst_tag` is passed to `seq_rest_write` as `tag` and thereby enters the couple restart file name.

Should resolve #88 