### PR TITLE
Add LFortran as compiler to build options

### DIFF
--- a/cmake/SetBuildOptions.cmake
+++ b/cmake/SetBuildOptions.cmake
@@ -12,12 +12,12 @@ endif()
 
 # Check if MPI is present. This should succeed if
 # the compilers were set to mpifort and mpicc.
-find_package(MPI REQUIRED)
 
 # Set default compiler = GNU if none was specified. 
 if(NOT COMPILER)
     set(COMPILER "${CMAKE_Fortran_COMPILER_ID}" CACHE STRING "Choose compiler toolchain." FORCE)
     set_property(CACHE COMPILER PROPERTY STRINGS "GNU" "Intel")
+    set_property(CACHE COMPILER PROPERTY STRINGS "GNU" "Intel" "LFortran")
 endif()
 
 # Set compiler specific flags.
@@ -44,6 +44,12 @@ elseif(COMPILER STREQUAL "Intel" OR COMPILER STREQUAL "IntelLLVM")
       set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -fpe0 -check all")
     endif()
     set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -debug minimal")
+elseif(COMPILER STREQUAL "LFortran")
+    add_compile_definitions(CPRLFORTRAN)
+    # There is an issue, some modules require --cpp as a flag in their compilation
+    # some flat out break, if we put --cpp
+    # For more information see https://github.com/HPSCTerrSys/eCLM/issues/98.
+    # set(CMAKE_Fortran_FLAGS "--cpp")
 else()
     message(FATAL_ERROR "COMPILER='${COMPILER}' is not supported.")
 endif()


### PR DESCRIPTION
Provides the necessary changes to use LFortran as the compiler for this project to the extend that it currently can. Please note the corresponding issue to gain further information on how to use this. It provides a compilation script and references the required mpi wrapper library. #98 