### PR TITLE
Updated WTB_REPO_TAG to 0.5

### DIFF
--- a/.github/workflows/build_and_run_eCLM.yml
+++ b/.github/workflows/build_and_run_eCLM.yml
@@ -71,7 +71,7 @@ jobs:
       INSTALL_DIR: ${{ github.workspace }}/install
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       WTB_REPO_NAME: extpar_eclm_wuestebach_sp
-      WTB_REPO_TAG: 0.4
+      WTB_REPO_TAG: 0.5
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`extpar_eclm_wuestebach_sp v0.5` downloads the `clm5nl-gen` tool from `HPSCTerrSys/ectk`: https://icg4geo.icg.kfa-juelich.de/ExternalReposPublic/tsmp2-static-files/extpar_eclm_wuestebach_sp/-/commit/c520fad9ac6f34a2c3961ab4229cd71628f3d02e