### PR TITLE
Make LAPACK library required

### DIFF
--- a/src/clm5/CMakeLists.txt
+++ b/src/clm5/CMakeLists.txt
@@ -319,7 +319,7 @@ target_sources(${PROJECT_NAME}
         utils/spmdMod.F90
 )
 
-find_package(LAPACK)
+find_package(LAPACK REQUIRED)
 if(LAPACK_FOUND)
     target_link_libraries(${PROJECT_NAME} PRIVATE LAPACK::LAPACK)
 endif()


### PR DESCRIPTION
Absence of LAPACK should be caught at `cmake` configure stage; otherwise we get LAPACK linking errors which is already too late in the build process (see #118).