### PR TITLE
Disable the balance-check reporting in eCLM-ParFlow simulations

### DIFF
--- a/src/clm5/biogeophys/BalanceCheckMod.F90
+++ b/src/clm5/biogeophys/BalanceCheckMod.F90
@@ -356,6 +356,7 @@ contains
        end do
 
        found = .false.
+#ifndef COUP_OAS_PFL
        do c = bounds%begc, bounds%endc
           if (abs(errh2o(c)) > 1.e-9_r8) then
              found = .true.
@@ -446,6 +447,7 @@ contains
 #endif
           end if
        end if
+#endif
 
        ! Snow balance check
 
@@ -691,6 +693,7 @@ contains
 
        ! Soil energy balance check
 
+#ifndef COUP_OAS_PFL
        found = .false.
        do c = bounds%begc,bounds%endc
           if (col%active(c)) then
@@ -714,6 +717,7 @@ contains
           end if
 #endif
        end if
+#endif
 
      end associate
 

--- a/src/clm5/biogeophys/BalanceCheckMod.F90
+++ b/src/clm5/biogeophys/BalanceCheckMod.F90
@@ -403,13 +403,8 @@ contains
              write(iulog,*)'deltawb/dtime    = ',(endwb(indexc)-begwb(indexc))/dtime
              write(iulog,*)'deltaflux        = ',forc_rain_col(indexc)+forc_snow_col(indexc) - (qflx_evap_tot(indexc) + &
                   qflx_surf(indexc)+qflx_h2osfc_surf(indexc)+qflx_drain(indexc))
-#ifdef COUP_OAS_PFL
-             ! TODO: Balance errors must be fixed for fully coupled model (ICON-eCLM-ParFlow)
-             write(iulog,*)'Ignoring water balance error...'
-#else
              write(iulog,*)'clm model is stopping'
              call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
-#endif
           else if (abs(errh2o(indexc)) > 1.e-5_r8 .and. (DAnstep > skip_steps) ) then
 
              write(iulog,*)'clm model is stopping - error is greater than 1e-5 (mm)'
@@ -438,13 +433,8 @@ contains
              write(iulog,*)'qflx_drain_perched         = ',qflx_drain_perched(indexc)*dtime
              write(iulog,*)'qflx_glcice_dyn_water_flux = ',qflx_glcice_dyn_water_flux(indexc)*dtime
              write(iulog,*)'qflx_rootsoi_col(1:nlevsoil)  = ',qflx_rootsoi_col(indexc,:)*dtime
-#ifdef COUP_OAS_PFL
-             ! TODO: Balance errors must be fixed for fully coupled model (ICON-eCLM-ParFlow)
-             write(iulog,*)'Ignoring water balance error...'
-#else
              write(iulog,*)'clm model is stopping'
              call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
-#endif
           end if
        end if
 #endif
@@ -707,15 +697,10 @@ contains
           write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
           write(iulog,*)'nstep         = ',nstep
           write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)
-#ifdef COUP_OAS_PFL
-          ! TODO: Balance errors must be fixed for fully coupled model (ICON-eCLM-ParFlow)
-          write(iulog,*)'Ignoring soil balance error...'
-#else
           if (abs(errsoi_col(indexc)) > 1.e-4_r8 .and. (DAnstep > skip_steps) ) then
              write(iulog,*)'clm model is stopping'
              call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
           end if
-#endif
        end if
 #endif
 

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -472,7 +472,7 @@ contains
      do j = 1, nlevsoi
       if (lnd2atm_inst%qflx_parflow_grc(g,j) == spval) then
        lnd2atm_inst%qflx_parflow_grc(g,j) = 0._r8
-       write(iulog,*)'WARNING: qflx_parflow_grc is nan at grid point ',g,' level',j,' replaced with 0.'
+!       write(iulog,*)'WARNING: qflx_parflow_grc is nan at grid point ',g,' level',j,' replaced with 0.'
       end if
      end do
     enddo

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -472,7 +472,6 @@ contains
      do j = 1, nlevsoi
       if (lnd2atm_inst%qflx_parflow_grc(g,j) == spval) then
        lnd2atm_inst%qflx_parflow_grc(g,j) = 0._r8
-!       write(iulog,*)'WARNING: qflx_parflow_grc is nan at grid point ',g,' level',j,' replaced with 0.'
       end if
      end do
     enddo


### PR DESCRIPTION
Suppresses excessive logging output of balance check errors / nan warnings during eCLM-ParFlow simulations to keep log sizes manageable and improve performance.

Long-term integration:
In the long run, this should incorporate or align with #80 or even better include an accurate balance check