### PR TITLE
eCLM-ParFlow: Normalize ParFlow source term over the gridcell

### DIFF
--- a/src/clm5/biogeophys/SoilHydrologyMod.F90
+++ b/src/clm5/biogeophys/SoilHydrologyMod.F90
@@ -2379,7 +2379,10 @@ contains
           qflx_parflow       =>    waterflux_inst%qflx_parflow_col         & ! source/sink flux passed to ParFlow for each soil layer
           )
 
-         ! COUP_OAS_PFL
+         ! Zero every column first. Any columns left at spval would return the mean over the
+         ! contributing fraction instead of the gridcell mean by c2g.
+         qflx_parflow(bounds%begc:bounds%endc, 1:nlevsoi) = 0._r8
+
          ! Calculate here the source/sink term for ParFlow
          do fc = 1, num_hydrologyc
             c = filter_hydrologyc(fc)

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -466,15 +466,6 @@ contains
          waterflux_inst%qflx_parflow_col (bounds%begc:bounds%endc, :), &
          lnd2atm_inst%qflx_parflow_grc   (bounds%begg:bounds%endg, :), &
          c2l_scale_type= 'unity',  l2g_scale_type='unity' )
-
-    ! adjust nan values after c2g, need to be rechecked
-    do g = bounds%begg, bounds%endg
-     do j = 1, nlevsoi
-      if (lnd2atm_inst%qflx_parflow_grc(g,j) == spval) then
-       lnd2atm_inst%qflx_parflow_grc(g,j) = 0._r8
-      end if
-     end do
-    enddo
 #endif
 
 #ifdef USE_PDAF


### PR DESCRIPTION
Fixes #131.

## Summary

`qflx_parflow_col` is left at `spval` on every column that `ParFlowDrainage` does not assign, e.g. lake, glacier, wetland and the non-pervious urban types. `c2g` excludes those from its denominator as well as its numerator, so that the flux handed to ParFlow was the mean over the hydrologically active fraction while ParFlow applies it over the whole cell. Zeroing the array before the assignment loops makes the non-contributing columns count as explicit zeros, restoring full-gridcell normalization and making the `spval to 0` workaround in `lnd2atmMod` unnecessary.

## Details

See #131 for details

## Side effects

`QPARFLOW` history output reports `0` rather than the fill value on non-contributing columns, since the array is now zeroed every timestep rather than left at its initial `spval` value.