### PR TITLE
Enabled history fields that are disabled when use_cn=true

### DIFF
--- a/.github/workflows/build_and_run_eCLM.yml
+++ b/.github/workflows/build_and_run_eCLM.yml
@@ -75,14 +75,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libxml2-utils pylint wget cmake netcdf-bin libnetcdf-dev libnetcdff-dev libpnetcdf-dev
-          version: 1.0
-          execute_install_scripts: true
+
+      #
+      # This should be uncommented once https://github.com/awalsh128/cache-apt-pkgs-action/issues/221 is solved
+      #
+      #- uses: awalsh128/cache-apt-pkgs-action@latest
+      #  with:
+      #    packages: libxml2-utils pylint wget cmake netcdf-bin libnetcdf-dev libnetcdff-dev libpnetcdf-dev
+      #    version: 1.0
+      #    execute_install_scripts: true
+
+      #
+      # Temporary workaround to the awalsh/cache-apt-pkgs problem above
+      #
+      - name: Install primary eCLM dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libxml2-utils pylint wget cmake netcdf-bin libnetcdf-dev libnetcdff-dev libpnetcdf-dev
 
       - name: Download MPI Fortran compiler
-        run: sudo apt-get install gfortran openmpi-bin libopenmpi-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install gfortran openmpi-bin libopenmpi-dev
 
       - if: matrix.config.use_oasis == 'True'
         name: Cache OASIS3-MCT

--- a/src/clm5/biogeophys/SoilStateType.F90
+++ b/src/clm5/biogeophys/SoilStateType.F90
@@ -214,37 +214,44 @@ contains
          avgflag='A', long_name='soil matric potential (vegetated landunits only)', &
          ptr_col=this%smp_l_col, set_spec=spval, l2g_scale_type='veg')
 
-    this%root_conductance_patch(begp:endp,:) = spval
-    call hist_addfld2d (fname='KROOT', units='1/s', type2d='levsoi', &
-       avgflag='A', long_name='root conductance each soil layer', &
-       ptr_patch=this%root_conductance_patch, default='inactive')
+       this%root_conductance_patch(begp:endp,:) = spval
+       call hist_addfld2d (fname='KROOT', units='1/s', type2d='levsoi', &
+          avgflag='A', long_name='root conductance each soil layer', &
+          ptr_patch=this%root_conductance_patch, default='inactive')
 
-    this%soil_conductance_patch(begp:endp,:) = spval
-    call hist_addfld2d (fname='KSOIL', units='1/s', type2d='levsoi', &
-       avgflag='A', long_name='soil conductance in each soil layer', &
-       ptr_patch=this%soil_conductance_patch, default='inactive')
+       this%soil_conductance_patch(begp:endp,:) = spval
+       call hist_addfld2d (fname='KSOIL', units='1/s', type2d='levsoi', &
+          avgflag='A', long_name='soil conductance in each soil layer', &
+          ptr_patch=this%soil_conductance_patch, default='inactive')
 
+#ifndef COUP_OAS_PFL
+    if (use_cn) then    ! Necessary to enable this history fields when coupled with Parflow.
+#endif
+       this%bsw_col(begc:endc,:) = spval
+       call hist_addfld2d (fname='bsw', units='unitless', type2d='levgrnd', &
+            avgflag='A', long_name='clap and hornberger B', &
+            ptr_col=this%bsw_col, default='inactive')
+#ifndef COUP_OAS_PFL
+    end if
+#endif
 
     if (use_dynroot) then
        this%rootfr_patch(begp:endp,:) = spval
        call hist_addfld2d (fname='ROOTFR', units='proportion', type2d='levgrnd', &
             avgflag='A', long_name='fraction of roots in each soil layer', &
             ptr_patch=this%rootfr_patch, default='active')
+    end if
 
+    if ( use_dynroot ) then
        this%root_depth_patch(begp:endp) = spval
         call hist_addfld1d (fname='ROOT_DEPTH', units="m", &
              avgflag='A', long_name='rooting depth', &
              ptr_patch=this%root_depth_patch )
-    end if
+     end if
 
 #ifndef COUP_OAS_PFL
-    if (use_cn) then   ! Necessary to enable this history fields when coupled with Parflow.
+    if (use_cn) then
 #endif
-       this%bsw_col(begc:endc,:) = spval 
-       call hist_addfld2d (fname='bsw', units='unitless', type2d='levgrnd', &
-            avgflag='A', long_name='clap and hornberger B', &
-            ptr_col=this%bsw_col, default='inactive')
-
        this%rootr_patch(begp:endp,:) = spval
        call hist_addfld2d (fname='ROOTR', units='proportion', type2d='levgrnd', &
             avgflag='A', long_name='effective fraction of roots in each soil layer', &
@@ -259,21 +266,6 @@ contains
        call hist_addfld2d (fname='SOILPSI', units='MPa', type2d='levgrnd', &
             avgflag='A', long_name='soil water potential in each soil layer', &
             ptr_col=this%soilpsi_col, default='inactive')
-
-       this%watsat_col(begc:endc,:) = spval 
-       call hist_addfld2d (fname='watsat', units='m^3/m^3', type2d='levgrnd', &
-            avgflag='A', long_name='water saturated', &
-            ptr_col=this%watsat_col, default='inactive')
-
-       this%eff_porosity_col(begc:endc,:) = spval
-       call hist_addfld2d (fname='EFF_POROSITY', units='proportion', type2d='levgrnd', &
-            avgflag='A', long_name='effective porosity = porosity - vol_ice', &
-            ptr_col=this%eff_porosity_col, default='inactive')
-
-       this%watfc_col(begc:endc,:) = spval 
-       call hist_addfld2d (fname='watfc', units='m^3/m^3', type2d='levgrnd', &
-            avgflag='A', long_name='water field capacity', &
-            ptr_col=this%watfc_col, default='inactive')
 #ifndef COUP_OAS_PFL
     end if
 #endif
@@ -304,6 +296,26 @@ contains
          avgflag='A', long_name='urban factor limiting ground evap', &
          ptr_col=this%soilalpha_u_col, set_nourb=spval, default='inactive')
 
+#ifndef COUP_OAS_PFL
+    if (use_cn) then
+#endif
+       this%watsat_col(begc:endc,:) = spval
+       call hist_addfld2d (fname='watsat', units='m^3/m^3', type2d='levgrnd', &
+            avgflag='A', long_name='water saturated', &
+            ptr_col=this%watsat_col, default='inactive')
+
+       this%eff_porosity_col(begc:endc,:) = spval
+       call hist_addfld2d (fname='EFF_POROSITY', units='proportion', type2d='levgrnd', &
+            avgflag='A', long_name='effective porosity = porosity - vol_ice', &
+            ptr_col=this%eff_porosity_col, default='inactive')
+
+       this%watfc_col(begc:endc,:) = spval
+       call hist_addfld2d (fname='watfc', units='m^3/m^3', type2d='levgrnd', &
+            avgflag='A', long_name='water field capacity', &
+            ptr_col=this%watfc_col, default='inactive')
+#ifndef COUP_OAS_PFL
+    end if
+#endif
 
     this%soilresis_col(begc:endc) = spval
     call hist_addfld1d (fname='SOILRESIS',  units='s/m',  &

--- a/src/clm5/biogeophys/SoilStateType.F90
+++ b/src/clm5/biogeophys/SoilStateType.F90
@@ -214,58 +214,69 @@ contains
          avgflag='A', long_name='soil matric potential (vegetated landunits only)', &
          ptr_col=this%smp_l_col, set_spec=spval, l2g_scale_type='veg')
 
-       this%root_conductance_patch(begp:endp,:) = spval
-       call hist_addfld2d (fname='KROOT', units='1/s', type2d='levsoi', &
-          avgflag='A', long_name='root conductance each soil layer', &
-          ptr_patch=this%root_conductance_patch, default='inactive')
+    this%root_conductance_patch(begp:endp,:) = spval
+    call hist_addfld2d (fname='KROOT', units='1/s', type2d='levsoi', &
+       avgflag='A', long_name='root conductance each soil layer', &
+       ptr_patch=this%root_conductance_patch, default='inactive')
 
-       this%soil_conductance_patch(begp:endp,:) = spval
-       call hist_addfld2d (fname='KSOIL', units='1/s', type2d='levsoi', &
-          avgflag='A', long_name='soil conductance in each soil layer', &
-          ptr_patch=this%soil_conductance_patch, default='inactive')
+    this%soil_conductance_patch(begp:endp,:) = spval
+    call hist_addfld2d (fname='KSOIL', units='1/s', type2d='levsoi', &
+       avgflag='A', long_name='soil conductance in each soil layer', &
+       ptr_patch=this%soil_conductance_patch, default='inactive')
 
-    if (use_cn) then
-       this%bsw_col(begc:endc,:) = spval 
-       call hist_addfld2d (fname='bsw', units='unitless', type2d='levgrnd', &
-            avgflag='A', long_name='clap and hornberger B', &
-            ptr_col=this%bsw_col, default='inactive')
-    end if
 
     if (use_dynroot) then
        this%rootfr_patch(begp:endp,:) = spval
        call hist_addfld2d (fname='ROOTFR', units='proportion', type2d='levgrnd', &
             avgflag='A', long_name='fraction of roots in each soil layer', &
             ptr_patch=this%rootfr_patch, default='active')
-    end if
 
-    if ( use_dynroot ) then
        this%root_depth_patch(begp:endp) = spval
         call hist_addfld1d (fname='ROOT_DEPTH', units="m", &
              avgflag='A', long_name='rooting depth', &
              ptr_patch=this%root_depth_patch )
-     end if
+    end if
 
-    if (use_cn) then
+#ifndef COUP_OAS_PFL
+    if (use_cn) then   ! Necessary to enable this history fields when coupled with Parflow.
+#endif
+       this%bsw_col(begc:endc,:) = spval 
+       call hist_addfld2d (fname='bsw', units='unitless', type2d='levgrnd', &
+            avgflag='A', long_name='clap and hornberger B', &
+            ptr_col=this%bsw_col, default='inactive')
+
        this%rootr_patch(begp:endp,:) = spval
        call hist_addfld2d (fname='ROOTR', units='proportion', type2d='levgrnd', &
             avgflag='A', long_name='effective fraction of roots in each soil layer', &
             ptr_patch=this%rootr_patch, default='inactive')
-    end if
 
-    if (use_cn) then
        this%rootr_col(begc:endc,:) = spval
        call hist_addfld2d (fname='ROOTR_COLUMN', units='proportion', type2d='levgrnd', &
             avgflag='A', long_name='effective fraction of roots in each soil layer', &
             ptr_col=this%rootr_col, default='inactive')
        
-    end if
-
-    if (use_cn) then
        this%soilpsi_col(begc:endc,:) = spval
        call hist_addfld2d (fname='SOILPSI', units='MPa', type2d='levgrnd', &
             avgflag='A', long_name='soil water potential in each soil layer', &
             ptr_col=this%soilpsi_col, default='inactive')
+
+       this%watsat_col(begc:endc,:) = spval 
+       call hist_addfld2d (fname='watsat', units='m^3/m^3', type2d='levgrnd', &
+            avgflag='A', long_name='water saturated', &
+            ptr_col=this%watsat_col, default='inactive')
+
+       this%eff_porosity_col(begc:endc,:) = spval
+       call hist_addfld2d (fname='EFF_POROSITY', units='proportion', type2d='levgrnd', &
+            avgflag='A', long_name='effective porosity = porosity - vol_ice', &
+            ptr_col=this%eff_porosity_col, default='inactive')
+
+       this%watfc_col(begc:endc,:) = spval 
+       call hist_addfld2d (fname='watfc', units='m^3/m^3', type2d='levgrnd', &
+            avgflag='A', long_name='water field capacity', &
+            ptr_col=this%watfc_col, default='inactive')
+#ifndef COUP_OAS_PFL
     end if
+#endif
 
     this%thk_col(begc:endc,-nlevsno+1:0) = spval
     data2dptr => this%thk_col(:,-nlevsno+1:0)
@@ -293,26 +304,6 @@ contains
          avgflag='A', long_name='urban factor limiting ground evap', &
          ptr_col=this%soilalpha_u_col, set_nourb=spval, default='inactive')
 
-    if (use_cn) then
-       this%watsat_col(begc:endc,:) = spval 
-       call hist_addfld2d (fname='watsat', units='m^3/m^3', type2d='levgrnd', &
-            avgflag='A', long_name='water saturated', &
-            ptr_col=this%watsat_col, default='inactive')
-    end if
-
-    if (use_cn) then
-       this%eff_porosity_col(begc:endc,:) = spval
-       call hist_addfld2d (fname='EFF_POROSITY', units='proportion', type2d='levgrnd', &
-            avgflag='A', long_name='effective porosity = porosity - vol_ice', &
-            ptr_col=this%eff_porosity_col, default='inactive')
-    end if
-
-    if (use_cn) then
-       this%watfc_col(begc:endc,:) = spval 
-       call hist_addfld2d (fname='watfc', units='m^3/m^3', type2d='levgrnd', &
-            avgflag='A', long_name='water field capacity', &
-            ptr_col=this%watfc_col, default='inactive')
-    end if
 
     this%soilresis_col(begc:endc) = spval
     call hist_addfld1d (fname='SOILRESIS',  units='s/m',  &


### PR DESCRIPTION
These soil state history fields should be enabled when eCLM is coupled with Parflow `(COUP_OAS_PFL=True)`. Also piggybacking a workaround for the CI issue described here: https://github.com/awalsh128/cache-apt-pkgs-action/issues/221