### PR TITLE
eCLM-ParFlow: Route impervious urban runoff into ParFlow

### DIFF
--- a/src/clm5/biogeophys/SoilHydrologyMod.F90
+++ b/src/clm5/biogeophys/SoilHydrologyMod.F90
@@ -2373,6 +2373,7 @@ contains
           qflx_drain         =>    waterflux_inst%qflx_drain_col         , & ! sub-surface runoff (mm H2O /s)
           qflx_drain_perched =>    waterflux_inst%qflx_drain_perched_col , & ! perched wt sub-surface runoff (mm H2O /s)         
           qflx_qrgwl         =>    waterflux_inst%qflx_qrgwl_col         , & ! qflx_surf at glaciers, wetlands, lakes (mm H2O /s)
+          qflx_surf          =>    waterflux_inst%qflx_surf_col          , & ! surface runoff (mm H2O /s)
           qflx_rsub_sat      =>    waterflux_inst%qflx_rsub_sat_col      , & ! soil saturation excess [mm h2o/s]
           qflx_infl          =>    waterflux_inst%qflx_infl_col          , & ! infiltration (mm H2O /s)
           qflx_rootsoi       =>    waterflux_inst%qflx_rootsoi_col       , & ! vegetation/soil water exchange (mm H2O/s) (+ = to atm) 
@@ -2409,6 +2410,17 @@ contains
                qflx_drain(c) = 0._r8
                ! This must be done for roofs and impervious road (walls will be zero)
                qflx_qrgwl(c) = qflx_snwcp_liq(c)
+
+               ! Instead of leaving as river runoff, impervious urban runoff enters
+               ! ParFlow through layer 1. It is zeroed here so it is not counted twice.
+               qflx_parflow(c,1:nlevsoi) = 0._r8
+               qflx_parflow(c,1)         = qflx_surf(c) + qflx_qrgwl(c)
+               qflx_surf(c)              = 0._r8
+               qflx_qrgwl(c)             = 0._r8
+
+               qflx_drain(c) = -sum(qflx_parflow(c,:))
+
+               qflx_parflow(c,1:nlevsoi) = qflx_parflow(c,1:nlevsoi) * sec_per_hr * m_per_mm * (1._r8/dz(c,1:nlevsoi))
             end if
          end do
      end associate

--- a/src/clm5/main/clm_driver.F90
+++ b/src/clm5/main/clm_driver.F90
@@ -1306,13 +1306,14 @@ contains
       end do
 
 #ifdef COUP_OAS_PFL
-      ! TSMP/bldsva/intf_oas3/clm3_5/mct/receive_fld_2pfl.F90
-      ! COUP_OAS_PFL
-      do f = 1, num_soilc
-        c = filter_soilc(f)
-        g = col%gridcell(c)  
-        pfl_psi(c,:) = atm2lnd_inst%pfl_psi_grc(g,:)
-        pfl_h2osoi_liq(c,:) = atm2lnd_inst%pfl_h2osoi_liq_grc(g,:)
+      ! Cover every column that soilwater_parflow will later overwrite.
+      do f = 1, num_nolakec
+        c = filter_nolakec(f)
+        if (col%hydrologically_active(c)) then
+          g = col%gridcell(c)
+          pfl_psi(c,:) = atm2lnd_inst%pfl_psi_grc(g,:)
+          pfl_h2osoi_liq(c,:) = atm2lnd_inst%pfl_h2osoi_liq_grc(g,:)
+        end if
       end do
 #endif
     end associate


### PR DESCRIPTION
Follow-up to #133, which fixes the urban state distribution. This adds the runoff routing that was originally part of it.

This is one special case of the general runoff / overland-flow treatment discussed in #136. Open for discussion whether eCLM should pre-classify infiltration versus runoff.

## Change

Roof, wall and impervious-road runoff left the domain as river runoff and never entered ParFlow's budget. It is now routed into ParFlow layer 1. Both runoff terms are zeroed where they are read so the water is not counted twice, and the exchange is booked to `qflx_drain` as for every other coupled column.

## More information

Can be found in #133 