### PR TITLE
eCLM-ParFlow: Ice impedance

### DIFF
--- a/src/clm5/biogeophys/SoilHydrologyType.F90
+++ b/src/clm5/biogeophys/SoilHydrologyType.F90
@@ -52,6 +52,9 @@ Module SoilHydrologyType
      real(r8), pointer :: max_infil_col     (:)     ! col VIC maximum infiltration rate calculated in VIC
      real(r8), pointer :: i_0_col           (:)     ! col VIC average saturation in top soil layers 
      real(r8), pointer :: ice_col           (:,:)   ! col VIC soil ice (kg/m2) for VIC soil layers
+#ifdef COUP_OAS_PFL
+     real(r8), pointer :: ice_impedance_col (:,:)   ! col ice impdeance
+#endif
 
 #ifdef USE_PDAF
      ! Yorck
@@ -130,6 +133,9 @@ contains
     allocate(this%qcharge_col       (begc:endc))                 ; this%qcharge_col       (:)     = nan
     allocate(this%fracice_col       (begc:endc,nlevgrnd))        ; this%fracice_col       (:,:)   = nan
     allocate(this%icefrac_col       (begc:endc,nlevgrnd))        ; this%icefrac_col       (:,:)   = nan
+#ifdef COUP_OAS_PFL
+    allocate(this%ice_impedance_col (begc:endc,nlevgrnd))        ; this%ice_impedance_col (:,:)   = nan
+#endif
     allocate(this%fcov_col          (begc:endc))                 ; this%fcov_col          (:)     = nan   
     allocate(this%fsat_col          (begc:endc))                 ; this%fsat_col          (:)     = nan
     allocate(this%h2osfc_thresh_col (begc:endc))                 ; this%h2osfc_thresh_col (:)     = nan
@@ -236,6 +242,9 @@ contains
     do c = bounds%begc, bounds%endc
        this%num_substeps_col(c) = spval
        this%icefrac_col(c,:) = spval
+#ifdef COUP_OAS_PFL
+       this%ice_impedance_col(c,:) = 1.0_r8
+#endif
     end do
 
   end subroutine InitCold

--- a/src/clm5/biogeophys/SoilHydrologyType.F90
+++ b/src/clm5/biogeophys/SoilHydrologyType.F90
@@ -235,6 +235,7 @@ contains
     ! averaging for the accum field
     do c = bounds%begc, bounds%endc
        this%num_substeps_col(c) = spval
+       this%icefrac_col(c,:) = spval
     end do
 
   end subroutine InitCold

--- a/src/clm5/biogeophys/SoilWaterMovementMod.F90
+++ b/src/clm5/biogeophys/SoilWaterMovementMod.F90
@@ -1489,16 +1489,21 @@ contains
       real(r8) :: s1                        ! "s" at interface of layer
       real(r8) :: s2(1:nlevgrnd)            ! "s" at layer node
       real(r8) :: vol_ice                   ! partial volume of ice
-      real(r8) :: imped                     ! ice impedance
       real(r8) :: hk                        ! hydraulic conductivity (mm/s)
 
       associate(&
-         smp_l             =>    soilstate_inst%smp_l_col             , & ! Input:  [real(r8) (:,:) ]  soil matrix potential [mm]         
-         h2osoi_liq        =>    waterstate_inst%h2osoi_liq_col       , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
-         pfl_h2osoi_liq    =>    waterstate_inst%pfl_h2osoi_liq_col   , & ! Input:  [real(r8) (:,:) ]  ParFlow soil water (mm)
-         pfl_psi           =>    waterstate_inst%pfl_psi_col          , & ! Input:  [real(r8) (:,:) ]  ParFlow pressure head (mm)
-         icefrac           =>    soilhydrology_inst%icefrac_col       , & ! Input:  [real(r8) (:,:) ]  fraction of ice
-         ice_impedance     =>    soilhydrology_inst%ice_impedance_col   & ! Input:  [real(r8) (:,:) ]  ice impedance
+         dz                =>    col%dz                              , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)
+         nbedrock          =>    col%nbedrock                        , & ! Input:  [integer  (:)   ]  index of shallowest bedrock layer
+         icefrac           =>    soilhydrology_inst%icefrac_col      , & ! Output: [real(r8) (:,:) ]  fraction of ice
+         ice_impedance     =>    soilhydrology_inst%ice_impedance_col, & ! Input:  [real(r8) (:,:) ]  ice impedance
+         watsat            =>    soilstate_inst%watsat_col           , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)
+         hk_l              =>    soilstate_inst%hk_l_col             , & ! Output: [real(r8) (:,:) ]  hydraulic conductivity (mm/s)
+         smp_l             =>    soilstate_inst%smp_l_col            , & ! Input:  [real(r8) (:,:) ]  soil matrix potential [mm]         
+         h2osoi_liq        =>    waterstate_inst%h2osoi_liq_col      , & ! Output: [real(r8) (:,:) ]  liquid water (kg/m2)
+         h2osoi_ice        =>    waterstate_inst%h2osoi_ice_col      , & ! Output: [real(r8) (:,:) ]  ice lens (kg/m2)
+         smpmin            =>    soilstate_inst%smpmin_col           , & ! Input:  [real(r8) (:)   ]  restriction for min of soil potential (mm)
+         pfl_h2osoi_liq    =>    waterstate_inst%pfl_h2osoi_liq_col  , & ! Input:  [real(r8) (:,:) ]  ParFlow soil water (mm)
+         pfl_psi           =>    waterstate_inst%pfl_psi_col           & ! Input:  [real(r8) (:,:) ]  ParFlow pressure head (mm)
          )  ! end associate statement
 
 
@@ -1515,14 +1520,6 @@ contains
                if (pfl_psi(c,j) <= 0) then
                   smp_l(c,j) = max(smpmin(c), pfl_psi(c,j))
                end if
-
-               if(j==nlevsoi)then
-                  call IceImpedance(icefrac(c,j), e_ice, ice_impedance(c,j) )
-               else if(j<nlevsoi)then
-                  call IceImpedance(0.5_r8*(icefrac(c,j) + icefrac(c,j+1)), e_ice, ice_impedance(c,j) )
-               else 
-                  ice_impedance(c,j) = 1._r8
-               endif
             end do
 
             ! ParFlow replaces the eCLM soil water solver. Recompute hk_l from the
@@ -1541,13 +1538,13 @@ contains
                ! hk is evaluated at the layer interface, as in the standalone model
                if (j == nlayers) then
                   s1 = s2(j)
-                  call IceImpedance(icefrac(c,j), e_ice, imped)
+                  call IceImpedance(icefrac(c,j), e_ice, ice_impedance(c,j))
                else
                   s1 = 0.5_r8 * (s2(j) + s2(j+1))
-                  call IceImpedance(0.5_r8*(icefrac(c,j) + icefrac(c,j+1)), e_ice, imped)
+                  call IceImpedance(0.5_r8*(icefrac(c,j) + icefrac(c,j+1)), e_ice, ice_impedance(c,j))
                end if
                s1 = min(max(s1, 0.01_r8), 1._r8)
-               call soil_water_retention_curve%soil_hk(c, j, s1, imped, &
+               call soil_water_retention_curve%soil_hk(c, j, s1, ice_impedance(c,j), &
                     soilstate_inst, hk)
                hk_l(c,j) = hk
             end do

--- a/src/clm5/biogeophys/SoilWaterMovementMod.F90
+++ b/src/clm5/biogeophys/SoilWaterMovementMod.F90
@@ -1455,7 +1455,7 @@ contains
       use decompMod            , only : bounds_type
       use clm_varctl           , only : iulog, use_hydrstress
       use clm_varcon           , only : denh2o, denice, e_ice
-      use clm_varpar           , only : nlevgrnd
+      use clm_varpar           , only : nlevsoi, nlevgrnd
       use clm_time_manager     , only : get_step_size, get_nstep
       use SoilStateType        , only : soilstate_type
       use SoilHydrologyType    , only : soilhydrology_type
@@ -1493,17 +1493,12 @@ contains
       real(r8) :: hk                        ! hydraulic conductivity (mm/s)
 
       associate(&
-         dz                =>    col%dz                             , & ! Input:  [real(r8) (:,:) ]  layer thickness (m)
-         nbedrock          =>    col%nbedrock                       , & ! Input:  [integer  (:)   ]  index of shallowest bedrock layer
-         icefrac           =>    soilhydrology_inst%icefrac_col     , & ! Output: [real(r8) (:,:) ]  fraction of ice
-         watsat            =>    soilstate_inst%watsat_col          , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)
-         hk_l              =>    soilstate_inst%hk_l_col            , & ! Output: [real(r8) (:,:) ]  hydraulic conductivity (mm/s)
-         smp_l             =>    soilstate_inst%smp_l_col           , & ! Input:  [real(r8) (:,:) ]  soil matrix potential [mm]         
-         h2osoi_liq        =>    waterstate_inst%h2osoi_liq_col     , & ! Output: [real(r8) (:,:) ]  liquid water (kg/m2)
-         h2osoi_ice        =>    waterstate_inst%h2osoi_ice_col     , & ! Output: [real(r8) (:,:) ]  ice lens (kg/m2)
-         smpmin            =>    soilstate_inst%smpmin_col          , & ! Input:  [real(r8) (:)   ]  restriction for min of soil potential (mm)
-         pfl_h2osoi_liq    =>    waterstate_inst%pfl_h2osoi_liq_col , & ! Input:  [real(r8) (:,:) ]  ParFlow soil water (mm)
-         pfl_psi           =>    waterstate_inst%pfl_psi_col          & ! Input:  [real(r8) (:,:) ]  ParFlow pressure head (mm)
+         smp_l             =>    soilstate_inst%smp_l_col             , & ! Input:  [real(r8) (:,:) ]  soil matrix potential [mm]         
+         h2osoi_liq        =>    waterstate_inst%h2osoi_liq_col       , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
+         pfl_h2osoi_liq    =>    waterstate_inst%pfl_h2osoi_liq_col   , & ! Input:  [real(r8) (:,:) ]  ParFlow soil water (mm)
+         pfl_psi           =>    waterstate_inst%pfl_psi_col          , & ! Input:  [real(r8) (:,:) ]  ParFlow pressure head (mm)
+         icefrac           =>    soilhydrology_inst%icefrac_col       , & ! Input:  [real(r8) (:,:) ]  fraction of ice
+         ice_impedance     =>    soilhydrology_inst%ice_impedance_col   & ! Input:  [real(r8) (:,:) ]  ice impedance
          )  ! end associate statement
 
 
@@ -1520,6 +1515,14 @@ contains
                if (pfl_psi(c,j) <= 0) then
                   smp_l(c,j) = max(smpmin(c), pfl_psi(c,j))
                end if
+
+               if(j==nlevsoi)then
+                  call IceImpedance(icefrac(c,j), e_ice, ice_impedance(c,j) )
+               else if(j<nlevsoi)then
+                  call IceImpedance(0.5_r8*(icefrac(c,j) + icefrac(c,j+1)), e_ice, ice_impedance(c,j) )
+               else 
+                  ice_impedance(c,j) = 1._r8
+               endif
             end do
 
             ! ParFlow replaces the eCLM soil water solver. Recompute hk_l from the

--- a/src/clm5/main/clm_driver.F90
+++ b/src/clm5/main/clm_driver.F90
@@ -1065,8 +1065,8 @@ contains
     call lnd2atm(bounds_proc,                                            &
          atm2lnd_inst, surfalb_inst, temperature_inst, frictionvel_inst, &
          waterstate_inst, waterflux_inst, irrigation_inst, energyflux_inst, &
-         solarabs_inst, drydepvel_inst,       &
-         vocemis_inst, fireemis_inst, dust_inst, ch4_inst, glc_behavior, &
+         solarabs_inst, drydepvel_inst, vocemis_inst, fireemis_inst, &
+         dust_inst, ch4_inst, glc_behavior, soilhydrology_inst, &
          lnd2atm_inst, &
 #ifdef USE_PDAF
          soilhydrology_inst, soilstate_inst, &

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -36,6 +36,7 @@ module lnd2atmMod
   use WaterstateType       , only : waterstate_type
   use IrrigationMod        , only : irrigation_type 
   use glcBehaviorMod       , only : glc_behavior_type
+  use SoilHydrologyType    , only : soilhydrology_type
   use glc2lndMod           , only : glc2lnd_type
   use ColumnType           , only : col
   use LandunitType         , only : lun
@@ -135,10 +136,7 @@ contains
        waterstate_inst, waterflux_inst, irrigation_inst, energyflux_inst, &
        solarabs_inst, drydepvel_inst,  &
        vocemis_inst, fireemis_inst, dust_inst, ch4_inst, glc_behavior, &
-       lnd2atm_inst, &
-#ifdef USE_PDAF
-       soilhydrology_inst, soilstate_inst, &
-#endif
+       soilhydrology_inst, lnd2atm_inst, &
        net_carbon_exchange_grc) 
     !
     ! !DESCRIPTION:
@@ -164,6 +162,7 @@ contains
     type(dust_type)             , intent(in)    :: dust_inst
     type(ch4_type)              , intent(in)    :: ch4_inst
     type(glc_behavior_type)     , intent(in)    :: glc_behavior
+    type(soilhydrology_type)    , intent(in)    :: soilhydrology_inst
     type(lnd2atm_type)          , intent(inout) :: lnd2atm_inst 
 #ifdef USE_PDAF
     ! Yorck
@@ -578,6 +577,21 @@ contains
 
           averaging_var = 0
 
+    call c2g( bounds, nlevsoi, &
+         soilhydrology_inst%icefrac_col (bounds%begc:bounds%endc, :), &
+         lnd2atm_inst%ice_frac_grc   (bounds%begg:bounds%endg, :), &
+         c2l_scale_type= 'unity',  l2g_scale_type='unity' )
+
+    do c = bounds%begc, bounds%endc
+     if (col%hydrologically_active(c)) then
+       if (col%itype(c) == istsoil .or. col%itype(c) == istcrop) then
+         g = col%gridcell(c)
+         do j = 1, nlevsoi
+          ! Convert eCLM fluxes (mm/s) to ParFlow fluxes (1/hr): 
+          !             1/hr                 =             [mm/s]                 *   [s/hr]   *  [m/mm]  *     [1/m] 
+          lnd2atm_inst%qflx_parflow_grc(g,j) = lnd2atm_inst%qflx_parflow_grc(g,j) * sec_per_hr * m_per_mm * (1/col%dz(c,j))
+         enddo
+       end if
      end if
 
      averaging_var = averaging_var+1

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -137,6 +137,9 @@ contains
        solarabs_inst, drydepvel_inst,  &
        vocemis_inst, fireemis_inst, dust_inst, ch4_inst, glc_behavior, &
        soilhydrology_inst, lnd2atm_inst, &
+#ifdef USE_PDAF
+       soilstate_inst, &
+#endif
        net_carbon_exchange_grc) 
     !
     ! !DESCRIPTION:

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -578,8 +578,8 @@ contains
           averaging_var = 0
 
     call c2g( bounds, nlevgrnd, &
-         soilhydrology_inst%icefrac_col (bounds%begc:bounds%endc, :), &
-         lnd2atm_inst%ice_frac_grc   (bounds%begg:bounds%endg, :), &
+         soilhydrology_inst%ice_impedance_col (bounds%begc:bounds%endc, :), &
+         lnd2atm_inst%ice_impedance_grc       (bounds%begg:bounds%endg, :), &
          c2l_scale_type= 'unity',  l2g_scale_type='unity' )
 
     do c = bounds%begc, bounds%endc

--- a/src/clm5/main/lnd2atmMod.F90
+++ b/src/clm5/main/lnd2atmMod.F90
@@ -577,7 +577,7 @@ contains
 
           averaging_var = 0
 
-    call c2g( bounds, nlevsoi, &
+    call c2g( bounds, nlevgrnd, &
          soilhydrology_inst%icefrac_col (bounds%begc:bounds%endc, :), &
          lnd2atm_inst%ice_frac_grc   (bounds%begg:bounds%endg, :), &
          c2l_scale_type= 'unity',  l2g_scale_type='unity' )

--- a/src/clm5/main/lnd2atmType.F90
+++ b/src/clm5/main/lnd2atmType.F90
@@ -192,7 +192,7 @@ contains
     allocate(this%qflx_liq_from_ice_col(begc:endc))          ; this%qflx_liq_from_ice_col(:)   =ival
 #ifdef COUP_OAS_PFL
     allocate(this%qflx_parflow_grc     (begg:endg,1:nlevsoi)); this%qflx_parflow_grc     (:,:) =ival
-    allocate(this%ice_frac_grc         (begg:endg,1:nlevsoi)); this%ice_frac_grc         (:,:) =ival
+    allocate(this%ice_frac_grc         (begg:endg,1:nlevgrnd)); this%ice_frac_grc         (:,:) =ival
 #endif
     allocate(this%qirrig_grc           (begg:endg))          ; this%qirrig_grc           (:)   =ival
 
@@ -348,7 +348,7 @@ contains
          ptr_lnd=this%qflx_parflow_grc, default='inactive')
 
     this%ice_frac_grc(begg:endg, :) = 0._r8
-    call hist_addfld2d (fname='FRAC_ICE', units='unitless', type2d='levsoi', &
+    call hist_addfld2d (fname='FRAC_ICE', units='unitless', type2d='levgrnd', &
          avgflag='A', long_name='soil ice fraction sent to ParFlow', &
          ptr_lnd=this%ice_frac_grc, default='inactive')
 #endif

--- a/src/clm5/main/lnd2atmType.F90
+++ b/src/clm5/main/lnd2atmType.F90
@@ -77,6 +77,7 @@ module lnd2atmType
      real(r8), pointer :: qflx_liq_from_ice_col   (:)   => null() ! liquid runoff from converted ice runoff
 #ifdef COUP_OAS_PFL
      real(r8), pointer :: qflx_parflow_grc        (:,:) => null() ! source/sink flux per soil layer sent to ParFlow [1/hr] [- out from root]
+     real(r8), pointer :: ice_frac_grc            (:,:) => null() ! soil ice fraction (values in [0,1])
 #endif
      real(r8), pointer :: qirrig_grc              (:)   => null() ! irrigation flux
 
@@ -191,6 +192,7 @@ contains
     allocate(this%qflx_liq_from_ice_col(begc:endc))          ; this%qflx_liq_from_ice_col(:)   =ival
 #ifdef COUP_OAS_PFL
     allocate(this%qflx_parflow_grc     (begg:endg,1:nlevsoi)); this%qflx_parflow_grc     (:,:) =ival
+    allocate(this%ice_frac_grc         (begg:endg,1:nlevsoi)); this%ice_frac_grc         (:,:) =ival
 #endif
     allocate(this%qirrig_grc           (begg:endg))          ; this%qirrig_grc           (:)   =ival
 
@@ -344,6 +346,11 @@ contains
     call hist_addfld2d (fname='QPARFLOW_TO_OASIS', units='1/hr', type2d='levsoi', &
          avgflag='A', long_name='source/sink flux per soil layer sent to ParFlow', &
          ptr_lnd=this%qflx_parflow_grc, default='inactive')
+
+    this%ice_frac_grc(begg:endg, :) = 0._r8
+    call hist_addfld2d (fname='FRAC_ICE', units='unitless', type2d='levsoi', &
+         avgflag='A', long_name='soil ice fraction sent to ParFlow', &
+         ptr_lnd=this%ice_frac_grc, default='inactive')
 #endif
   end subroutine InitHistory
 

--- a/src/clm5/main/lnd2atmType.F90
+++ b/src/clm5/main/lnd2atmType.F90
@@ -77,7 +77,7 @@ module lnd2atmType
      real(r8), pointer :: qflx_liq_from_ice_col   (:)   => null() ! liquid runoff from converted ice runoff
 #ifdef COUP_OAS_PFL
      real(r8), pointer :: qflx_parflow_grc        (:,:) => null() ! source/sink flux per soil layer sent to ParFlow [1/hr] [- out from root]
-     real(r8), pointer :: ice_frac_grc            (:,:) => null() ! soil ice fraction (values in [0,1])
+     real(r8), pointer :: ice_impedance_grc       (:,:) => null() ! soil ice impedance (values in [0,1])
 #endif
      real(r8), pointer :: qirrig_grc              (:)   => null() ! irrigation flux
 
@@ -192,7 +192,7 @@ contains
     allocate(this%qflx_liq_from_ice_col(begc:endc))          ; this%qflx_liq_from_ice_col(:)   =ival
 #ifdef COUP_OAS_PFL
     allocate(this%qflx_parflow_grc     (begg:endg,1:nlevsoi)); this%qflx_parflow_grc     (:,:) =ival
-    allocate(this%ice_frac_grc         (begg:endg,1:nlevgrnd)); this%ice_frac_grc         (:,:) =ival
+    allocate(this%ice_impedance_grc    (begg:endg,1:nlevgrnd)); this%ice_impedance_grc   (:,:) =1.0_r8
 #endif
     allocate(this%qirrig_grc           (begg:endg))          ; this%qirrig_grc           (:)   =ival
 
@@ -347,10 +347,10 @@ contains
          avgflag='A', long_name='source/sink flux per soil layer sent to ParFlow', &
          ptr_lnd=this%qflx_parflow_grc, default='inactive')
 
-    this%ice_frac_grc(begg:endg, :) = 0._r8
-    call hist_addfld2d (fname='FRAC_ICE', units='unitless', type2d='levgrnd', &
-         avgflag='A', long_name='soil ice fraction sent to ParFlow', &
-         ptr_lnd=this%ice_frac_grc, default='inactive')
+    this%ice_impedance_grc(begg:endg, :) = 1._r8
+    call hist_addfld2d (fname='ICE_IMPEDANCE', units='unitless', type2d='levgrnd', &
+         avgflag='A', long_name='soil ice impedance sent to ParFlow', &
+         ptr_lnd=this%ice_impedance_grc, default='inactive')
 #endif
   end subroutine InitHistory
 

--- a/src/clm5/oasis3/oas_defineMod.F90
+++ b/src/clm5/oasis3/oas_defineMod.F90
@@ -107,7 +107,7 @@ contains
     var_nodims(2) = nlevgrnd         ! number of fields in a bundle
     call oasis_def_var(oas_sat_id, "ECLM_SOILLIQ", grid_id, var_nodims, OASIS_In, OASIS_Real, ierror)
     call oasis_def_var(oas_psi_id, "ECLM_PSI", grid_id, var_nodims, OASIS_In, OASIS_Real, ierror)
-    call oasis_def_var(oas_ice_frac_id, "ECLM_ICE_FRAC", grid_id, var_nodims, OASIS_Out, OASIS_Real, ierror)
+    call oasis_def_var(oas_ice_impedance_id, "ECLM_ICE_IMPEDANCE", grid_id, var_nodims, OASIS_Out, OASIS_Real, ierror)
 #endif
 
 #ifdef COUP_OAS_ICON

--- a/src/clm5/oasis3/oas_defineMod.F90
+++ b/src/clm5/oasis3/oas_defineMod.F90
@@ -103,12 +103,12 @@ contains
     var_nodims(2) = nlevsoi   ! number of fields in a bundle
 
     call oasis_def_var(oas_et_loss_id, "ECLM_ET", grid_id, var_nodims, OASIS_Out, OASIS_Real, ierror)
-    call oasis_def_var(oas_ice_frac_id, "ECLM_ICE_FRAC", grid_id, var_nodims, OASIS_Out, OASIS_Real, ierror)
 
     var_nodims(2) = nlevgrnd         ! number of fields in a bundle
     call oasis_def_var(oas_sat_id, "ECLM_SOILLIQ", grid_id, var_nodims, OASIS_In, OASIS_Real, ierror)
     call oasis_def_var(oas_psi_id, "ECLM_PSI", grid_id, var_nodims, OASIS_In, OASIS_Real, ierror)
-#endif 
+    call oasis_def_var(oas_ice_frac_id, "ECLM_ICE_FRAC", grid_id, var_nodims, OASIS_Out, OASIS_Real, ierror)
+#endif
 
 #ifdef COUP_OAS_ICON
 

--- a/src/clm5/oasis3/oas_defineMod.F90
+++ b/src/clm5/oasis3/oas_defineMod.F90
@@ -102,8 +102,9 @@ contains
     var_nodims(1) = 1         ! unused
     var_nodims(2) = nlevsoi   ! number of fields in a bundle
 
-    call oasis_def_var(oas_et_loss_id, "ECLM_ET", grid_id, var_nodims, OASIS_Out, OASIS_Real, ierror) 
-    
+    call oasis_def_var(oas_et_loss_id, "ECLM_ET", grid_id, var_nodims, OASIS_Out, OASIS_Real, ierror)
+    call oasis_def_var(oas_ice_frac_id, "ECLM_ICE_FRAC", grid_id, var_nodims, OASIS_Out, OASIS_Real, ierror)
+
     var_nodims(2) = nlevgrnd         ! number of fields in a bundle
     call oasis_def_var(oas_sat_id, "ECLM_SOILLIQ", grid_id, var_nodims, OASIS_In, OASIS_Real, ierror)
     call oasis_def_var(oas_psi_id, "ECLM_PSI", grid_id, var_nodims, OASIS_In, OASIS_Real, ierror)

--- a/src/clm5/oasis3/oas_sendReceiveMod.F90
+++ b/src/clm5/oasis3/oas_sendReceiveMod.F90
@@ -48,6 +48,7 @@ contains
     integer                           :: info
     
     call oasis_put(oas_et_loss_id, seconds_elapsed, lnd2atm_inst%qflx_parflow_grc, info)
+    call oasis_put(oas_ice_frac_id, seconds_elapsed, lnd2atm_inst%ice_frac_grc, info)
     
   end subroutine oas_send
 #endif

--- a/src/clm5/oasis3/oas_sendReceiveMod.F90
+++ b/src/clm5/oasis3/oas_sendReceiveMod.F90
@@ -48,7 +48,7 @@ contains
     integer                           :: info
     
     call oasis_put(oas_et_loss_id, seconds_elapsed, lnd2atm_inst%qflx_parflow_grc, info)
-    call oasis_put(oas_ice_frac_id, seconds_elapsed, lnd2atm_inst%ice_frac_grc, info)
+    call oasis_put(oas_ice_impedance_id, seconds_elapsed, lnd2atm_inst%ice_impedance_grc, info)
     
   end subroutine oas_send
 #endif

--- a/src/clm5/oasis3/oas_vardefMod.F90
+++ b/src/clm5/oasis3/oas_vardefMod.F90
@@ -3,7 +3,7 @@ module oas_vardefMod
   save
 
 #ifdef COUP_OAS_PFL
-  integer :: oas_psi_id, oas_et_loss_id, oas_sat_id
+  integer :: oas_psi_id, oas_et_loss_id, oas_sat_id, oas_ice_frac_id
 #endif
 
 #ifdef COUP_OAS_ICON

--- a/src/clm5/oasis3/oas_vardefMod.F90
+++ b/src/clm5/oasis3/oas_vardefMod.F90
@@ -3,7 +3,7 @@ module oas_vardefMod
   save
 
 #ifdef COUP_OAS_PFL
-  integer :: oas_psi_id, oas_et_loss_id, oas_sat_id, oas_ice_frac_id
+  integer :: oas_psi_id, oas_et_loss_id, oas_sat_id, oas_ice_impedance_id
 #endif
 
 #ifdef COUP_OAS_ICON


### PR DESCRIPTION
Adds the coupling field `ECLM_ICE_IMPEDANCE` which is then sent to ParFlow.

Original dev timestamps were from May-Aug 2023. Branch history has been recently rewritten with the command `git rebase --strategy-option theirs master`.